### PR TITLE
Specified file permissions

### DIFF
--- a/tasks/dockbarx-configure.yml
+++ b/tasks/dockbarx-configure.yml
@@ -6,6 +6,7 @@
     state: directory
     owner: "{{ item.username }}"
     group: "{{ item.username }}"
+    mode: 'u=rwx,go='
   with_items: "{{ users }}"
 
 - name: write xfce4 dockbarx config
@@ -15,4 +16,5 @@
     dest: "/home/{{ item.username }}/.config/xfce4/panel/dockbarx-9.rc"
     owner: "{{ item.username }}"
     group: "{{ item.username }}"
+    mode: 'u=rw,go='
   with_items: "{{ users }}"

--- a/tasks/xfce4-desktop-configure.yml
+++ b/tasks/xfce4-desktop-configure.yml
@@ -6,6 +6,7 @@
     state: directory
     owner: "{{ item.username }}"
     group: "{{ item.username }}"
+    mode: 'u=rwx,go='
   with_items: "{{ users }}"
 
 - name: write xfce4 power manager config
@@ -15,6 +16,7 @@
     dest: "/home/{{ item.username }}/.config/xfce4/xfconf/xfce-perchannel-xml/xfce4-power-manager.xml"
     owner: "{{ item.username }}"
     group: "{{ item.username }}"
+    mode: 'u=rw,go='
   with_items: "{{ users }}"
 
 - name: write xfce4 panel config
@@ -24,4 +26,5 @@
     dest: "/home/{{ item.username }}/.config/xfce4/xfconf/xfce-perchannel-xml/xfce4-panel.xml"
     owner: "{{ item.username }}"
     group: "{{ item.username }}"
+    mode: 'u=rw,go='
   with_items: "{{ users }}"

--- a/tests/test_role.py
+++ b/tests/test_role.py
@@ -22,6 +22,22 @@ def test_for_libdockbarx(File):
     assert docx.group == 'root'
     assert oct(docx.mode) == '0644'
 
+@pytest.mark.parametrize('dir_path', [
+    ('.config'),
+    ('.config/xfce4'),
+    ('.config/xfce4/panel'),
+    ('.config/xfce4/xfconf'),
+    ('.config/xfce4/xfconf/xfce-perchannel-xml')
+])
+def test_for_config_dirs(File, dir_path):
+    dir = File('/home/test_usr/' + dir_path)
+
+    assert dir.exists
+    assert dir.is_directory
+    assert dir.user == 'test_usr'
+    assert dir.group == 'test_usr'
+    assert oct(dir.mode) == '0700'
+
 @pytest.mark.parametrize('config_path', [
     ('.config/xfce4/panel/dockbarx-9.rc'),
     ('.config/xfce4/xfconf/xfce-perchannel-xml/xfce4-power-manager.xml'),
@@ -34,4 +50,4 @@ def test_for_config(File, config_path):
     assert config_file.is_file
     assert config_file.user == 'test_usr'
     assert config_file.group == 'test_usr'
-    assert oct(config_file.mode) == '0644'
+    assert oct(config_file.mode) == '0600'


### PR DESCRIPTION
While the defaults worked it's more secure the specify the minimum permissions.