### PR TITLE
Fixed case of title in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Example Playbook
           xdesktop_clock_format: '%d %b, %H:%M'
 ```
 
-More roles from GantSign
+More Roles From GantSign
 ------------------------
 
 You can find more roles from GantSign on [Ansible Galaxy](https://galaxy.ansible.com/gantsign).


### PR DESCRIPTION
For consistency the title needs to be in titlecase like the others.