### PR TITLE
Line wrapping fix in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,8 @@ Xfce4 playbook:
 More Roles From GantSign
 ------------------------
 
-You can find more roles from GantSign on [Ansible Galaxy](https://galaxy.ansible.com/gantsign).
+You can find more roles from GantSign on
+[Ansible Galaxy](https://galaxy.ansible.com/gantsign).
 
 Development & Testing
 ---------------------


### PR DESCRIPTION
Wrap at 80 columns where possible.