### PR TITLE
Added support for Ubuntu 16.04

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,9 @@ Requirements
 
 * Ubuntu
 
+    * Wily (15.10)
+    * Xenial (16.04)
+
 Role Variables
 --------------
 

--- a/molecule.yml
+++ b/molecule.yml
@@ -4,6 +4,6 @@ ansible:
 
 docker:
   containers:
-  - name: ansible-role-xdesktop-01
+  - name: ansible-role-xdesktop-ubuntu-xenial
     image: ubuntu
-    image_version: '15.10'
+    image_version: '16.04'

--- a/tasks/xfce4-desktop-install.yml
+++ b/tasks/xfce4-desktop-install.yml
@@ -5,12 +5,6 @@
     name: xubuntu-core
     state: present
 
-- name: install xfce4-mixer
-  become: yes
-  apt:
-    name: xfce4-mixer
-    state: present
-
 - name: install xfce4-taskmanager
   become: yes
   apt:

--- a/templates/xfce4-panel.xml.j2
+++ b/templates/xfce4-panel.xml.j2
@@ -11,8 +11,8 @@
         <value type="int" value="9"/>
         <value type="int" value="3"/>
         <value type="int" value="4"/>
-        <value type="int" value="7"/>
         <value type="int" value="5"/>
+        <value type="int" value="7"/>
         <value type="int" value="8"/>
         <value type="int" value="6"/>
       </property>
@@ -40,6 +40,21 @@
         <value type="string" value="networkmanager applet"/>
       </property>
     </property>
+    <property name="plugin-5" type="string" value="indicator">
+      <property name="blacklist" type="array">
+        <value type="string" value="com.canonical.indicator.bluetooth"/>
+        <value type="string" value="com.canonical.indicator.datetime"/>
+        <value type="string" value="com.canonical.indicator.keyboard"/>
+        <value type="string" value="com.canonical.indicator.power"/>
+        <value type="string" value="com.canonical.indicator.session"/>
+        <value type="string" value="libappmenu.so"/>
+      </property>
+      <property name="known-indicators" type="array">
+        <value type="string" value="libapplication.so"/>
+        <value type="string" value="com.canonical.indicator.messages"/>
+        <value type="string" value="com.canonical.indicator.sound"/>
+      </property>
+    </property>
     <property name="plugin-7" type="string" value="separator">
       <property name="style" type="uint" value="0"/>
       <property name="expand" type="bool" value="false"/>
@@ -48,12 +63,6 @@
       {% if xdesktop_clock_format is defined and xdesktop_clock_format not in ('', None, omit) %}
       <property name="digital-format" type="string" value="{{ xdesktop_clock_format }}"/>
       {% endif %}
-    </property>
-    <property name="plugin-5" type="string" value="mixer">
-      <property name="sound-card" type="string" value=""/>
-      <property name="track" type="string" value=""/>
-      <property name="command" type="string" value="xfce4-mixer"/>
-      <property name="enable-keyboard-shortcuts" type="bool" value="true"/>
     </property>
     <property name="plugin-6" type="string" value="showdesktop"/>
     <property name="plugin-9" type="string" value="dockbarx"/>

--- a/tests/test_xfce4.py
+++ b/tests/test_xfce4.py
@@ -7,7 +7,6 @@ testinfra_hosts = AnsibleRunner('.molecule/ansible_inventory').get_hosts('all')
 
 @pytest.mark.parametrize('executable', [
     'xfce4-about',
-    'xfce4-mixer',
     'xfce4-taskmanager',
     'dockx',
     'evince',


### PR DESCRIPTION
The `xfce4-mixer` plugin isn't available in 16.04 so switched to indicator plugin for sound control.