### PR TITLE
Renamed handler to make it unique to this role

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,4 +1,4 @@
 ---
-- name: compile glib schemas
+- name: compile glib schemas xdesktop
   become: yes
   command: '/usr/bin/glib-compile-schemas {{ xdesktop_glib_schemas_directory }}'

--- a/tasks/unity-desktop-configure.yml
+++ b/tasks/unity-desktop-configure.yml
@@ -17,7 +17,7 @@
     group: root
     mode: 'u=rw,go=r'
   notify:
-    - compile glib schemas
+    - compile glib schemas xdesktop
 
 - name: write gnome lock screen config
   become: yes
@@ -28,4 +28,4 @@
     group: root
     mode: 'u=rw,go=r'
   notify:
-    - compile glib schemas
+    - compile glib schemas xdesktop


### PR DESCRIPTION
Since the handler is specific to properties of this role the name needs to be unique to this role.