### PR TITLE
Reverted handler back to task

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,4 +1,4 @@
 ---
-- name: compile glib schemas xdesktop
+- name: compile glib schemas
   become: yes
   command: '/usr/bin/glib-compile-schemas {{ xdesktop_glib_schemas_directory }}'

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,4 +1,2 @@
 ---
-- name: compile glib schemas
-  become: yes
-  command: '/usr/bin/glib-compile-schemas {{ xdesktop_glib_schemas_directory }}'
+# handlers file for xdesktop

--- a/tasks/unity-desktop-configure.yml
+++ b/tasks/unity-desktop-configure.yml
@@ -17,7 +17,7 @@
     group: root
     mode: 'u=rw,go=r'
   notify:
-    - compile glib schemas xdesktop
+    - compile glib schemas
 
 - name: write gnome lock screen config
   become: yes
@@ -28,4 +28,4 @@
     group: root
     mode: 'u=rw,go=r'
   notify:
-    - compile glib schemas xdesktop
+    - compile glib schemas

--- a/tasks/unity-desktop-configure.yml
+++ b/tasks/unity-desktop-configure.yml
@@ -16,8 +16,7 @@
     owner: root
     group: root
     mode: 'u=rw,go=r'
-  notify:
-    - compile glib schemas
+  register: screensaver_config
 
 - name: write gnome lock screen config
   become: yes
@@ -27,5 +26,9 @@
     owner: root
     group: root
     mode: 'u=rw,go=r'
-  notify:
-    - compile glib schemas
+  register: lockscreen_config
+
+- name: apply glib schemas changes
+  become: yes
+  command: "/usr/bin/glib-compile-schemas {{ xdesktop_glib_schemas_directory }}"
+  when: screensaver_config.changed or lockscreen_config.changed

--- a/tasks/unity-desktop-configure.yml
+++ b/tasks/unity-desktop-configure.yml
@@ -29,6 +29,11 @@
   register: lockscreen_config
 
 - name: apply glib schemas changes
+  tags:
+    # Suppress warning: [ANSIBLE0016] Tasks that run when changed should likely be handlers
+    # Since the command is invoked with an argument that is role specific it
+    # doesn't make sense to use a handler, which are global to the playbook.
+    - skip_ansible_lint
   become: yes
   command: "/usr/bin/glib-compile-schemas {{ xdesktop_glib_schemas_directory }}"
   when: screensaver_config.changed or lockscreen_config.changed


### PR DESCRIPTION
Since handlers are global they aren't a good fit for commands that have a role specific argument.