### PR TITLE
Switched to single quotes for YAML strings

### DIFF
--- a/tasks/dockbarx-configure.yml
+++ b/tasks/dockbarx-configure.yml
@@ -2,7 +2,7 @@
 - name: create xfce4 dockbarx config directory
   become: yes
   file:
-    path: "{{ xdesktop_xfce4_custom_config_dir }}/xfce4/panel"
+    path: '{{ xdesktop_xfce4_custom_config_dir }}/xfce4/panel'
     state: directory
     owner: root
     group: root
@@ -12,7 +12,7 @@
   become: yes
   template:
     src: dockbarx-9.rc.j2
-    dest: "{{ xdesktop_xfce4_custom_config_dir }}/xfce4/panel/dockbarx-9.rc"
+    dest: '{{ xdesktop_xfce4_custom_config_dir }}/xfce4/panel/dockbarx-9.rc'
     owner: root
     group: root
     mode: 'u=rw,go=r'

--- a/tasks/unity-desktop-configure.yml
+++ b/tasks/unity-desktop-configure.yml
@@ -12,7 +12,7 @@
   become: yes
   template:
     src: screensaver.gschema.override.j2
-    dest: "{{ xdesktop_glib_schemas_directory }}/20_ansible_screensaver.gschema.override"
+    dest: '{{ xdesktop_glib_schemas_directory }}/20_ansible_screensaver.gschema.override'
     owner: root
     group: root
     mode: 'u=rw,go=r'
@@ -22,7 +22,7 @@
   become: yes
   template:
     src: lockscreen.gschema.override.j2
-    dest: "{{ xdesktop_glib_schemas_directory }}/20_ansible_lockscreen.gschema.override"
+    dest: '{{ xdesktop_glib_schemas_directory }}/20_ansible_lockscreen.gschema.override'
     owner: root
     group: root
     mode: 'u=rw,go=r'
@@ -35,5 +35,5 @@
     # doesn't make sense to use a handler, which are global to the playbook.
     - skip_ansible_lint
   become: yes
-  command: "/usr/bin/glib-compile-schemas {{ xdesktop_glib_schemas_directory }}"
+  command: '/usr/bin/glib-compile-schemas {{ xdesktop_glib_schemas_directory }}'
   when: screensaver_config.changed or lockscreen_config.changed

--- a/tasks/xfce4-desktop-configure.yml
+++ b/tasks/xfce4-desktop-configure.yml
@@ -2,7 +2,7 @@
 - name: create custom config directory
   become: yes
   file:
-    path: "{{ xdesktop_xfce4_custom_config_dir }}"
+    path: '{{ xdesktop_xfce4_custom_config_dir }}'
     state: directory
     owner: root
     group: root
@@ -11,7 +11,7 @@
 - name: create Xsession.d directory
   become: yes
   file:
-    path: "{{ xdesktop_xsession_d_dir }}"
+    path: '{{ xdesktop_xsession_d_dir }}'
     state: directory
     owner: root
     group: root
@@ -29,7 +29,7 @@
 - name: create xfce4 perchannel config directory
   become: yes
   file:
-    path: "{{ xdesktop_xfce4_custom_config_dir }}/xfce4/xfconf/xfce-perchannel-xml"
+    path: '{{ xdesktop_xfce4_custom_config_dir }}/xfce4/xfconf/xfce-perchannel-xml'
     state: directory
     owner: root
     group: root
@@ -39,7 +39,7 @@
   become: yes
   template:
     src: xfce4-power-manager.xml.j2
-    dest: "{{ xdesktop_xfce4_custom_config_dir }}/xfce4/xfconf/xfce-perchannel-xml/xfce4-power-manager.xml"
+    dest: '{{ xdesktop_xfce4_custom_config_dir }}/xfce4/xfconf/xfce-perchannel-xml/xfce4-power-manager.xml'
     owner: root
     group: root
     mode: 'u=rw,go=r'
@@ -47,7 +47,7 @@
 - name: create xfce4 panel config directory
   become: yes
   file:
-    path: "{{ xdesktop_xfce4_custom_config_dir }}/xfce4/panel"
+    path: '{{ xdesktop_xfce4_custom_config_dir }}/xfce4/panel'
     state: directory
     owner: root
     group: root
@@ -57,7 +57,7 @@
   become: yes
   template:
     src: xfce4-panel.xml.j2
-    dest: "{{ xdesktop_xfce4_custom_config_dir }}/xfce4/panel/default.xml"
+    dest: '{{ xdesktop_xfce4_custom_config_dir }}/xfce4/panel/default.xml'
     owner: root
     group: root
     mode: 'u=rw,go=r'


### PR DESCRIPTION
Switched to single quotes (rather than double quotes) for YAML strings where escaping isn't required.