### PR TITLE
Dropped documented support for Ubuntu Wily

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,6 @@ Requirements
 
 * Ubuntu
 
-    * Wily (15.10)
     * Xenial (16.04)
 
 Role Variables

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -7,7 +7,7 @@ galaxy_info:
   platforms:
   - name: Ubuntu
     versions:
-    - wily
+    - xenial
   galaxy_tags:
     - xfce4
     - xubuntu


### PR DESCRIPTION
It's no longer a supported Ubuntu version.