### PR TITLE
Resolved deprecation warning for include

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -4,10 +4,6 @@
     that:
       - "xdesktop_desktop in ('unity', 'xfce4')"
 
-- include: unity-desktop.yml
-  when: xdesktop_desktop == 'unity'
+- include_tasks: '{{ xdesktop_desktop }}-desktop.yml'
 
-- include: xfce4-desktop.yml
-  when: xdesktop_desktop == 'xfce4'
-
-- include: accessories.yml
+- import_tasks: accessories.yml

--- a/tasks/unity-desktop.yml
+++ b/tasks/unity-desktop.yml
@@ -1,4 +1,4 @@
 ---
-- include: unity-desktop-install.yml
+- import_tasks: unity-desktop-install.yml
 
-- include: unity-desktop-configure.yml
+- import_tasks: unity-desktop-configure.yml

--- a/tasks/xfce4-desktop.yml
+++ b/tasks/xfce4-desktop.yml
@@ -1,6 +1,6 @@
 ---
-- include: xfce4-desktop-configure.yml
+- import_tasks: xfce4-desktop-configure.yml
 
-- include: dockbarx-configure.yml
+- import_tasks: dockbarx-configure.yml
 
-- include: xfce4-desktop-install.yml
+- import_tasks: xfce4-desktop-install.yml


### PR DESCRIPTION
Since Ansible 2.4 `include` has been deprecated.

```
[DEPRECATION WARNING]: The use of 'include' for tasks has been deprecated. Use
'import_tasks' for static inclusions or 'include_tasks' for dynamic inclusions.
```