### PR TITLE
Added gnome-system-monitor for Unity desktop

### DIFF
--- a/tasks/unity-desktop-install.yml
+++ b/tasks/unity-desktop-install.yml
@@ -11,3 +11,5 @@
     - unity-lens-applications
     # Archive manager
     - file-roller
+    # TaskManager equivalent
+    - gnome-system-monitor


### PR DESCRIPTION
Gnome System Monitor is the Gnome equivalent to TaskManager.