### PR TITLE
Resolved apt module syntax deprecation warning

### DIFF
--- a/tasks/accessories.yml
+++ b/tasks/accessories.yml
@@ -2,24 +2,23 @@
 - name: install accessory apps and fonts
   become: yes
   apt:
-    name: '{{ item }}'
+    name:
+      # Text editor
+      - gedit
+      # Seahorse SSH agent GUI
+      - seahorse-daemon
+      # Evince PDF viewer
+      - evince
+      # Gnome Calculator
+      - gnome-calculator
+      # Meld - Diff/Merge tool
+      - meld
+      # Git-GUI graphical Git client
+      - git-gui
+      # Liberation fonts (Fonts with the same metrics as Times, Arial and Courier)
+      - fonts-liberation
+      # OpenSymbol fonts
+      - fonts-opensymbol
+      # Scientific and Technical Information eXchange fonts
+      - fonts-stix
     state: present
-  with_items:
-    # Text editor
-    - gedit
-    # Seahorse SSH agent GUI
-    - seahorse-daemon
-    # Evince PDF viewer
-    - evince
-    # Gnome Calculator
-    - gnome-calculator
-    # Meld - Diff/Merge tool
-    - meld
-    # Git-GUI graphical Git client
-    - git-gui
-    # Liberation fonts (Fonts with the same metrics as Times, Arial and Courier)
-    - fonts-liberation
-    # OpenSymbol fonts
-    - fonts-opensymbol
-    # Scientific and Technical Information eXchange fonts
-    - fonts-stix

--- a/tasks/gnome-desktop-install.yml
+++ b/tasks/gnome-desktop-install.yml
@@ -2,12 +2,11 @@
 - name: install ubuntu-desktop
   become: yes
   apt:
-    name: '{{ item }}'
+    name:
+      - ubuntu-desktop
+      # Archive manager
+      - file-roller
+      # TaskManager equivalent
+      - gnome-system-monitor
     state: present
     install_recommends: no
-  with_items:
-    - ubuntu-desktop
-    # Archive manager
-    - file-roller
-    # TaskManager equivalent
-    - gnome-system-monitor

--- a/tasks/unity-desktop-install.yml
+++ b/tasks/unity-desktop-install.yml
@@ -2,14 +2,13 @@
 - name: install ubuntu-desktop
   become: yes
   apt:
-    name: '{{ item }}'
+    name:
+      - ubuntu-desktop
+      # Without this the application menu doesn't work
+      - unity-lens-applications
+      # Archive manager
+      - file-roller
+      # TaskManager equivalent
+      - gnome-system-monitor
     state: present
     install_recommends: no
-  with_items:
-    - ubuntu-desktop
-    # Without this the application menu doesn't work
-    - unity-lens-applications
-    # Archive manager
-    - file-roller
-    # TaskManager equivalent
-    - gnome-system-monitor

--- a/tasks/xfce4-desktop-install.yml
+++ b/tasks/xfce4-desktop-install.yml
@@ -7,14 +7,13 @@
 - name: install xubuntu
   become: yes
   apt:
-    name: '{{ item }}'
+    name:
+      - xubuntu-core
+      - xfce4-taskmanager
+      - thunar-archive-plugin
+      - dockbarx
+      - xfce4-dockbarx-plugin
     state: present
-  with_items:
-    - xubuntu-core
-    - xfce4-taskmanager
-    - thunar-archive-plugin
-    - dockbarx
-    - xfce4-dockbarx-plugin
 
 # Remove screensaver (host OS has screensaver)
 - name: uninstall xscreensaver


### PR DESCRIPTION
```
[DEPRECATION WARNING]: Invoking "apt" only once while using a loop via
squash_actions is deprecated. Instead of using a loop to supply multiple items
and specifying `name: {{ item }}`, please use `name: [u'ubuntu-desktop', u
'file-roller', u'gnome-system-monitor']` and remove the loop. This feature will
 be removed in version 2.11. Deprecation warnings can be disabled by setting
deprecation_warnings=False in ansible.cfg.
[DEPRECATION WARNING]: Invoking "apt" only once while using a loop via
squash_actions is deprecated. Instead of using a loop to supply multiple items
and specifying `name: {{ item }}`, please use `name: [u'gedit', u'seahorse-
daemon', u'evince', u'gnome-calculator', u'meld', u'git-gui', u'fonts-
liberation', u'fonts-opensymbol', u'fonts-stix']` and remove the loop. This
feature will be removed in version 2.11. Deprecation warnings can be disabled
by setting deprecation_warnings=False in ansible.cfg.
```