### PR TITLE
Removed sudo key from Travis CI config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,9 +15,6 @@ matrix:
     - env:
         - MOLECULEW_ANSIBLE=2.9.1
 
-# Require the standard build environment
-sudo: required
-
 # Require Ubuntu 14.04
 dist: trusty
 


### PR DESCRIPTION
The key `sudo` has no effect anymore.