### PR TITLE
Updated Travis CI config to use jobs key instead of matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ env:
 
 # Spin off separate builds for each of the following versions
 # of Ansible and the desktop type.
-matrix:
+jobs:
   include:
     - env:
         - MOLECULEW_ANSIBLE=2.7.15


### PR DESCRIPTION
`jobs` is the new preferred name.